### PR TITLE
Enhanced support for windows filepath

### DIFF
--- a/html_checker/reporter.py
+++ b/html_checker/reporter.py
@@ -117,7 +117,8 @@ class ReportStore:
 
             # Clean prefix file path from reported path
             if path.startswith("file:"):
-                path = path[len("file:"):]
+                path = path[len("file:"): + 1].replace("%20", " ")
+                path = os.path.abspath(path)
 
             if path in self.registry:
                 if self.registry[path] is None:


### PR DESCRIPTION
Resolve issues where "Validator report contains unknow path" would raise due to path having spaces (converted to "%20") and UNC path would not convert to the windows path (i.e. / to \)